### PR TITLE
GraphQL Basics

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/tap": "^15.0.5",
         "concurrently": "^7.0.0",
         "fastify-tsconfig": "^1.0.1",
+        "prettier": "^2.8.3",
         "tap": "^16.1.0",
         "ts-node": "^10.4.0",
         "typescript": "^4.5.4"
@@ -2948,6 +2949,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process": {
@@ -8128,6 +8144,12 @@
       "requires": {
         "find-up": "^3.0.0"
       }
+    },
+    "prettier": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "dev": true
     },
     "process": {
       "version": "0.11.10",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/tap": "^15.0.5",
     "concurrently": "^7.0.0",
     "fastify-tsconfig": "^1.0.1",
+    "prettier": "^2.8.3",
     "tap": "^16.1.0",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4"

--- a/src/controllers/memberTypeController.ts
+++ b/src/controllers/memberTypeController.ts
@@ -1,0 +1,39 @@
+import { FastifyInstance } from 'fastify';
+import { HttpErrors } from '@fastify/sensible/lib/httpError';
+import { MemberTypeEntity } from '../utils/DB/entities/DBMemberTypes';
+import DB from '../utils/DB/DB';
+
+export default class MemberTypeController {
+  private declare db: DB;
+  private declare httpErrors: HttpErrors;
+
+  constructor(fastify: FastifyInstance) {
+    this.db = fastify.db;
+    this.httpErrors = fastify.httpErrors;
+  }
+
+  async getAllMemberTypes(): Promise<MemberTypeEntity[]> {
+    return await this.db.memberTypes.findMany();
+  }
+
+  async getMemberTypeById(id: string): Promise<MemberTypeEntity> {
+    const memberType = await this.db.memberTypes.findOne({
+      key: 'id',
+      equals: id,
+    });
+    if (!memberType) {
+      throw this.httpErrors.notFound('No memberTypes with such id');
+    }
+    return memberType;
+  }
+
+  async updateMemberType(
+    id: string,
+    memberTypeData: Partial<Omit<MemberTypeEntity, 'id'>>
+  ): Promise<MemberTypeEntity> {
+    if (!Object.keys(memberTypeData).length) {
+      throw this.httpErrors.badRequest('Add fields you want to update');
+    }
+    return await this.db.memberTypes.change(id, memberTypeData);
+  }
+}

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -1,0 +1,54 @@
+import { FastifyInstance } from 'fastify';
+import { HttpErrors } from '@fastify/sensible/lib/httpError';
+import { PostEntity } from '../utils/DB/entities/DBPosts';
+import DB from '../utils/DB/DB';
+import { NoRequiredEntity } from '../utils/DB/errors/NoRequireEntity.error';
+
+export default class PostController {
+  private declare db: DB;
+  private declare httpErrors: HttpErrors;
+
+  constructor(fastify: FastifyInstance) {
+    this.db = fastify.db;
+    this.httpErrors = fastify.httpErrors;
+  }
+
+  async getAllPosts(): Promise<PostEntity[]> {
+    return await this.db.posts.findMany();
+  }
+
+  async getPostById(id: string): Promise<PostEntity> {
+    const post = await this.db.posts.findOne({
+      key: 'id',
+      equals: id,
+    });
+    if (!post) {
+      throw this.httpErrors.notFound('No posts with such id');
+    }
+    return post;
+  }
+
+  async createNewPost(postData: Omit<PostEntity, 'id'>): Promise<PostEntity> {
+    return await this.db.posts.create(postData);
+  }
+
+  async deletePost(id: string): Promise<PostEntity> {
+    try {
+      return await this.db.posts.delete(id);
+    } catch (err) {
+      throw err instanceof NoRequiredEntity
+        ? this.httpErrors.badRequest('No posts with such id')
+        : err;
+    }
+  }
+
+  async updatePost(
+    id: string,
+    postData: Partial<Omit<PostEntity, 'id' | 'userId'>>
+  ): Promise<PostEntity> {
+    if (!Object.keys(postData).length) {
+      throw this.httpErrors.badRequest('Add fields you want to update');
+    }
+    return await this.db.posts.change(id, postData);
+  }
+}

--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -51,4 +51,8 @@ export default class PostController {
     }
     return await this.db.posts.change(id, postData);
   }
+
+  async getUserPosts(userId: string): Promise<PostEntity[]> {
+    return await this.db.posts.findMany({ key: 'userId', equals: userId });
+  }
 }

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -1,0 +1,72 @@
+import { FastifyInstance } from 'fastify';
+import { HttpErrors } from '@fastify/sensible/lib/httpError';
+import { ProfileEntity } from '../utils/DB/entities/DBProfiles';
+import DB from '../utils/DB/DB';
+import { NoRequiredEntity } from '../utils/DB/errors/NoRequireEntity.error';
+
+export default class ProfileController {
+  private declare db: DB;
+  private declare httpErrors: HttpErrors;
+
+  constructor(fastify: FastifyInstance) {
+    this.db = fastify.db;
+    this.httpErrors = fastify.httpErrors;
+  }
+
+  async getAllProfiles(): Promise<ProfileEntity[]> {
+    return await this.db.profiles.findMany();
+  }
+
+  async getProfileById(id: string): Promise<ProfileEntity> {
+    const profile = await this.db.profiles.findOne({
+      key: 'id',
+      equals: id,
+    });
+    if (!profile) {
+      throw this.httpErrors.notFound('No profiles with such id');
+    }
+    return profile;
+  }
+
+  async createNewProfile(
+    profileData: Omit<ProfileEntity, 'id'>
+  ): Promise<ProfileEntity> {
+    const allowedMemberType = await this.db.memberTypes.findOne({
+      key: 'id',
+      equals: profileData.memberTypeId,
+    });
+    const userAlreadyHasProfile = await this.db.profiles.findOne({
+      key: 'userId',
+      equals: profileData.userId,
+    });
+    if (userAlreadyHasProfile) {
+      throw this.httpErrors.badRequest(
+        'User with this id already have a profile'
+      );
+    }
+    if (!allowedMemberType) {
+      throw this.httpErrors.badRequest("No such member id's");
+    }
+    return await this.db.profiles.create(profileData);
+  }
+
+  async deleteProfile(id: string): Promise<ProfileEntity> {
+    try {
+      return await this.db.profiles.delete(id);
+    } catch (err) {
+      throw err instanceof NoRequiredEntity
+        ? this.httpErrors.badRequest('No profiles with such id')
+        : err;
+    }
+  }
+
+  async updateProfile(
+    id: string,
+    profileData: Partial<Omit<ProfileEntity, 'id' | 'userId'>>
+  ): Promise<ProfileEntity> {
+    if (!Object.keys(profileData).length) {
+      throw this.httpErrors.badRequest('Add fields you want to update');
+    }
+    return await this.db.profiles.change(id, profileData);
+  }
+}

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -69,4 +69,15 @@ export default class ProfileController {
     }
     return await this.db.profiles.change(id, profileData);
   }
+
+  async getUsersProfile(userId: string): Promise<ProfileEntity> {
+    const profile = await this.db.profiles.findOne({
+      key: 'userId',
+      equals: userId,
+    });
+    if (!profile) {
+      throw this.httpErrors.notFound("This user haven't profile yet");
+    }
+    return profile;
+  }
 }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -121,4 +121,16 @@ export default class UserController {
     }
     return await this.db.users.change(id, userData);
   }
+
+  async getUserSubscribes(ids: string[]): Promise<UserEntity[]> {
+    const users = await this.db.users.findMany();
+    return users.filter((user) => ids.includes(user.id));
+  }
+
+  async getUserFollowers(userId: string): Promise<UserEntity[]> {
+    return await this.db.users.findMany({
+      key: 'subscribedToUserIds',
+      inArray: userId,
+    });
+  }
 }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,0 +1,124 @@
+import { FastifyInstance } from 'fastify';
+import { HttpErrors } from '@fastify/sensible/lib/httpError';
+import { UserEntity } from '../utils/DB/entities/DBUsers';
+import DB from '../utils/DB/DB';
+import { NoRequiredEntity } from '../utils/DB/errors/NoRequireEntity.error';
+
+export default class UserController {
+  private declare db: DB;
+  private declare httpErrors: HttpErrors;
+
+  constructor(fastify: FastifyInstance) {
+    this.db = fastify.db;
+    this.httpErrors = fastify.httpErrors;
+  }
+
+  async getAllUsers(): Promise<UserEntity[]> {
+    return await this.db.users.findMany();
+  }
+
+  async getUserById(id: string): Promise<UserEntity> {
+    const user = await this.db.users.findOne({
+      key: 'id',
+      equals: id,
+    });
+    if (!user) {
+      throw this.httpErrors.notFound('No users with such id');
+    }
+    return user;
+  }
+
+  async createNewUser(
+    userData: Omit<UserEntity, 'id' | 'subscribedToUserIds'>
+  ): Promise<UserEntity> {
+    return await this.db.users.create(userData);
+  }
+
+  async deleteUser(id: string): Promise<UserEntity> {
+    try {
+      const user = await this.db.users.delete(id);
+      const followers = await this.db.users.findMany({
+        key: 'subscribedToUserIds',
+        inArray: user.id,
+      });
+      for (const follower of followers) {
+        const updatedSubscribes = follower.subscribedToUserIds.filter(
+          (id) => id !== user.id
+        );
+        await this.db.users.change(follower.id, {
+          subscribedToUserIds: updatedSubscribes,
+        });
+      }
+      const userPosts = await this.db.posts.findMany({
+        key: 'userId',
+        equals: user.id,
+      });
+      if (userPosts.length) {
+        for (const userPost of userPosts) {
+          await this.db.posts.delete(userPost.id);
+        }
+      }
+      const userProfile = await this.db.profiles.findOne({
+        key: 'userId',
+        equals: user.id,
+      });
+      if (userProfile) {
+        await this.db.profiles.delete(userProfile.id);
+      }
+      return user;
+    } catch (err) {
+      throw err instanceof NoRequiredEntity
+        ? this.httpErrors.badRequest('No users with such id')
+        : err;
+    }
+  }
+
+  async subscribeToUser(
+    userId: string,
+    subscribeTo: string
+  ): Promise<UserEntity> {
+    const user = await this.db.users.findOne({
+      key: 'id',
+      equals: userId,
+    });
+    if (!user) {
+      throw this.httpErrors.badRequest('No users with such id');
+    }
+    const updatedSubscribes = [...user.subscribedToUserIds, subscribeTo];
+    return await this.db.users.change(user.id, {
+      subscribedToUserIds: updatedSubscribes,
+    });
+  }
+
+  async unsubscribeFromUser(
+    userId: string,
+    unsubscribeFrom: string
+  ): Promise<UserEntity> {
+    const user = await this.db.users.findOne({
+      key: 'id',
+      equals: userId,
+    });
+    if (!user) {
+      throw this.httpErrors.notFound('No users with such id');
+    }
+    if (!user.subscribedToUserIds.includes(unsubscribeFrom)) {
+      throw this.httpErrors.badRequest('User is not following received user');
+    }
+    const updatedSubscribes = user.subscribedToUserIds.filter(
+      (id) => id !== unsubscribeFrom
+    );
+    return await this.db.users.change(user.id, {
+      subscribedToUserIds: updatedSubscribes,
+    });
+  }
+
+  async updateUser(
+    id: string,
+    userData: Partial<Omit<UserEntity, 'id'>>
+  ): Promise<UserEntity> {
+    if (!Object.keys(userData).length) {
+      throw this.httpErrors.badRequest('Add fields you want to update');
+    }
+    return await this.db.users.change(id, userData);
+  }
+}

--- a/src/routes/graphql/graphql-mutations/memberTypeMutations.ts
+++ b/src/routes/graphql/graphql-mutations/memberTypeMutations.ts
@@ -1,0 +1,24 @@
+import { FastifyInstance } from 'fastify';
+import { GraphQLInt, GraphQLNonNull, GraphQLString } from 'graphql/type';
+import { MemberTypeType } from '../graphql-queries/memberTypeQueries';
+import { MemberTypeEntity } from '../../../utils/DB/entities/DBMemberTypes';
+import MemberTypeController from '../../../controllers/memberTypeController';
+
+export const updateMemberTypeMutation = {
+  type: MemberTypeType,
+  args: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  },
+  resolve: async (
+    source: any,
+    args: MemberTypeEntity,
+    context: FastifyInstance
+  ) => {
+    return new MemberTypeController(context).updateMemberType(args.id, {
+      discount: args.discount,
+      monthPostsLimit: args.monthPostsLimit,
+    });
+  },
+};

--- a/src/routes/graphql/graphql-mutations/postMutations.ts
+++ b/src/routes/graphql/graphql-mutations/postMutations.ts
@@ -1,0 +1,40 @@
+import { FastifyInstance } from 'fastify';
+import { GraphQLID, GraphQLNonNull, GraphQLString } from 'graphql/type';
+import { PostType } from '../graphql-queries/postQueries';
+import { PostEntity } from '../../../utils/DB/entities/DBPosts';
+import PostController from '../../../controllers/postController';
+
+export const addPostMutation = {
+  type: PostType,
+  args: {
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    content: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  resolve: async (
+    source: any,
+    args: Omit<PostEntity, 'id'>,
+    context: FastifyInstance
+  ) => {
+    return new PostController(context).createNewPost(args);
+  },
+};
+
+export const updatePostMutation = {
+  type: PostType,
+  args: {
+    id: { type: new GraphQLNonNull(GraphQLID) },
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+  },
+  resolve: async (
+    source: any,
+    args: Omit<PostEntity, 'userId'>,
+    context: FastifyInstance
+  ) => {
+    return new PostController(context).updatePost(args.id, {
+      title: args.title,
+      content: args.content,
+    });
+  },
+};

--- a/src/routes/graphql/graphql-mutations/profileMutations.ts
+++ b/src/routes/graphql/graphql-mutations/profileMutations.ts
@@ -1,0 +1,60 @@
+import { FastifyInstance } from 'fastify';
+import {
+  GraphQLID,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLString,
+} from 'graphql/type';
+import { ProfileType } from '../graphql-queries/profileQueries';
+import { ProfileEntity } from '../../../utils/DB/entities/DBProfiles';
+import ProfileController from '../../../controllers/profileController';
+
+export const addProfileMutation = {
+  type: ProfileType,
+  args: {
+    avatar: { type: new GraphQLNonNull(GraphQLString) },
+    sex: { type: new GraphQLNonNull(GraphQLString) },
+    birthday: { type: new GraphQLNonNull(GraphQLInt) },
+    country: { type: new GraphQLNonNull(GraphQLString) },
+    street: { type: new GraphQLNonNull(GraphQLString) },
+    city: { type: new GraphQLNonNull(GraphQLString) },
+    memberTypeId: { type: new GraphQLNonNull(GraphQLString) },
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  resolve: async (
+    source: any,
+    args: Omit<ProfileEntity, 'id'>,
+    context: FastifyInstance
+  ) => {
+    return new ProfileController(context).createNewProfile(args);
+  },
+};
+
+export const updateProfileMutation = {
+  type: ProfileType,
+  args: {
+    id: { type: new GraphQLNonNull(GraphQLID) },
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLInt },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+  },
+  resolve: async (
+    source: any,
+    args: Omit<ProfileEntity, 'userId'>,
+    context: FastifyInstance
+  ) => {
+    return new ProfileController(context).updateProfile(args.id, {
+      avatar: args.avatar,
+      sex: args.sex,
+      birthday: args.birthday,
+      country: args.country,
+      street: args.street,
+      city: args.city,
+      memberTypeId: args.memberTypeId,
+    });
+  },
+};

--- a/src/routes/graphql/graphql-mutations/userMutations.ts
+++ b/src/routes/graphql/graphql-mutations/userMutations.ts
@@ -25,6 +25,42 @@ export const addUserMutation = {
   },
 };
 
+export const subscribeToUserMutation = {
+  type: UserType,
+  args: {
+    userId: { type: new GraphQLNonNull(GraphQLID) },
+    subscribedTo: { type: new GraphQLNonNull(GraphQLID) },
+  },
+  resolve: async (
+    source: any,
+    args: { userId: string; subscribeTo: string },
+    context: FastifyInstance
+  ) => {
+    return new UserController(context).subscribeToUser(
+      args.userId,
+      args.subscribeTo
+    );
+  },
+};
+
+export const unsubscribeFromUserMutation = {
+  type: UserType,
+  args: {
+    userId: { type: new GraphQLNonNull(GraphQLID) },
+    unsubscribeFrom: { type: new GraphQLNonNull(GraphQLID) },
+  },
+  resolve: async (
+    source: any,
+    args: { userId: string; unsubscribeFrom: string },
+    context: FastifyInstance
+  ) => {
+    return new UserController(context).unsubscribeFromUser(
+      args.userId,
+      args.unsubscribeFrom
+    );
+  },
+};
+
 export const updateUserMutation = {
   type: UserType,
   args: {

--- a/src/routes/graphql/graphql-mutations/userMutations.ts
+++ b/src/routes/graphql/graphql-mutations/userMutations.ts
@@ -1,0 +1,45 @@
+import { FastifyInstance } from 'fastify';
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLString,
+} from 'graphql/type';
+import { UserType } from '../graphql-queries/userQueries';
+import UserController from '../../../controllers/userController';
+import { UserEntity } from '../../../utils/DB/entities/DBUsers';
+
+export const addUserMutation = {
+  type: UserType,
+  args: {
+    firstName: { type: new GraphQLNonNull(GraphQLString) },
+    lastName: { type: new GraphQLNonNull(GraphQLString) },
+    email: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  resolve: async (
+    source: any,
+    args: Omit<UserEntity, 'id' | 'subscribedToUserIds'>,
+    context: FastifyInstance
+  ) => {
+    return new UserController(context).createNewUser(args);
+  },
+};
+
+export const updateUserMutation = {
+  type: UserType,
+  args: {
+    id: { type: new GraphQLNonNull(GraphQLID) },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    email: { type: GraphQLString },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLString) },
+  },
+  resolve: async (source: any, args: UserEntity, context: FastifyInstance) => {
+    return new UserController(context).updateUser(args.id, {
+      firstName: args.firstName,
+      lastName: args.lastName,
+      email: args.email,
+      subscribedToUserIds: args.subscribedToUserIds,
+    });
+  },
+};

--- a/src/routes/graphql/graphql-queries/memberTypeQueries.ts
+++ b/src/routes/graphql/graphql-queries/memberTypeQueries.ts
@@ -1,0 +1,35 @@
+import {
+  GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql/type';
+import { FastifyInstance } from 'fastify';
+import MemberTypeController from '../../../controllers/memberTypeController';
+
+const MemberTypeType = new GraphQLObjectType({
+  name: 'MemberType',
+  fields: () => ({
+    id: { type: GraphQLString },
+    discount: { type: GraphQLInt },
+    monthPostsLimit: { type: GraphQLInt },
+  }),
+});
+
+export const memberTypeQuery = {
+  type: MemberTypeType,
+  args: { id: { type: GraphQLString } },
+  resolve: async (
+    source: any,
+    args: { id: string },
+    context: FastifyInstance
+  ) => {
+    return new MemberTypeController(context).getMemberTypeById(args.id);
+  },
+};
+export const memberTypesQuery = {
+  type: new GraphQLList(MemberTypeType),
+  resolve: async (source: any, args: undefined, context: FastifyInstance) => {
+    return new MemberTypeController(context).getAllMemberTypes();
+  },
+};

--- a/src/routes/graphql/graphql-queries/memberTypeQueries.ts
+++ b/src/routes/graphql/graphql-queries/memberTypeQueries.ts
@@ -7,7 +7,7 @@ import {
 import { FastifyInstance } from 'fastify';
 import MemberTypeController from '../../../controllers/memberTypeController';
 
-const MemberTypeType = new GraphQLObjectType({
+export const MemberTypeType = new GraphQLObjectType({
   name: 'MemberType',
   fields: () => ({
     id: { type: GraphQLString },

--- a/src/routes/graphql/graphql-queries/postQueries.ts
+++ b/src/routes/graphql/graphql-queries/postQueries.ts
@@ -7,7 +7,7 @@ import {
 import { FastifyInstance } from 'fastify';
 import PostController from '../../../controllers/postController';
 
-const PostType = new GraphQLObjectType({
+export const PostType = new GraphQLObjectType({
   name: 'Post',
   fields: () => ({
     id: { type: GraphQLID },

--- a/src/routes/graphql/graphql-queries/postQueries.ts
+++ b/src/routes/graphql/graphql-queries/postQueries.ts
@@ -1,0 +1,36 @@
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql/type';
+import { FastifyInstance } from 'fastify';
+import PostController from '../../../controllers/postController';
+
+const PostType = new GraphQLObjectType({
+  name: 'Post',
+  fields: () => ({
+    id: { type: GraphQLID },
+    title: { type: GraphQLString },
+    content: { type: GraphQLString },
+    userId: { type: GraphQLID },
+  }),
+});
+
+export const postQuery = {
+  type: PostType,
+  args: { id: { type: GraphQLID } },
+  resolve: async (
+    source: any,
+    args: { id: string },
+    context: FastifyInstance
+  ) => {
+    return new PostController(context).getPostById(args.id);
+  },
+};
+export const postsQuery = {
+  type: new GraphQLList(PostType),
+  resolve: async (source: any, args: undefined, context: FastifyInstance) => {
+    return new PostController(context).getAllPosts();
+  },
+};

--- a/src/routes/graphql/graphql-queries/profileQueries.ts
+++ b/src/routes/graphql/graphql-queries/profileQueries.ts
@@ -1,0 +1,46 @@
+import {
+  GraphQLID,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql/type';
+import { FastifyInstance } from 'fastify';
+import ProfileController from '../../../controllers/profileController';
+
+const ProfileType = new GraphQLObjectType({
+  name: 'Profile',
+  fields: () => ({
+    id: { type: GraphQLID },
+    avatar: { type: GraphQLString },
+    sex: { type: GraphQLString },
+    birthday: { type: GraphQLInt },
+    country: { type: GraphQLString },
+    street: { type: GraphQLString },
+    city: { type: GraphQLString },
+    memberTypeId: { type: GraphQLString },
+    userId: { type: GraphQLID },
+  }),
+});
+
+export const profileQuery = {
+  type: ProfileType,
+  args: { id: { type: GraphQLID } },
+  resolve: async (
+    source: any,
+    args: { id: string },
+    context: FastifyInstance
+  ) => {
+    return new ProfileController(context).getProfileById(args.id);
+  },
+};
+export const profilesQuery = {
+  type: new GraphQLList(ProfileType),
+  resolve: async (
+    source: any,
+    args: { id: string },
+    context: FastifyInstance
+  ) => {
+    return new ProfileController(context).getAllProfiles();
+  },
+};

--- a/src/routes/graphql/graphql-queries/profileQueries.ts
+++ b/src/routes/graphql/graphql-queries/profileQueries.ts
@@ -8,7 +8,7 @@ import {
 import { FastifyInstance } from 'fastify';
 import ProfileController from '../../../controllers/profileController';
 
-const ProfileType = new GraphQLObjectType({
+export const ProfileType = new GraphQLObjectType({
   name: 'Profile',
   fields: () => ({
     id: { type: GraphQLID },

--- a/src/routes/graphql/graphql-queries/userQueries.ts
+++ b/src/routes/graphql/graphql-queries/userQueries.ts
@@ -1,0 +1,38 @@
+import {
+  GraphQLID,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql/type';
+import { FastifyInstance } from 'fastify';
+import UserController from '../../../controllers/userController';
+
+const UserType = new GraphQLObjectType({
+  name: 'User',
+  fields: () => ({
+    id: { type: GraphQLID },
+    firstName: { type: GraphQLString },
+    lastName: { type: GraphQLString },
+    email: { type: GraphQLString },
+    subscribedToUserIds: { type: new GraphQLList(GraphQLID) },
+  }),
+});
+
+export const userQuery = {
+  type: UserType,
+  args: { id: { type: GraphQLID } },
+  resolve: async (
+    source: any,
+    args: { id: string },
+    context: FastifyInstance
+  ) => {
+    return new UserController(context).getUserById(args.id);
+  },
+};
+
+export const usersQuery = {
+  type: new GraphQLList(UserType),
+  resolve: async (source: any, args: undefined, context: FastifyInstance) => {
+    return new UserController(context).getAllUsers();
+  },
+};

--- a/src/routes/graphql/graphql-queries/userQueries.ts
+++ b/src/routes/graphql/graphql-queries/userQueries.ts
@@ -6,8 +6,14 @@ import {
 } from 'graphql/type';
 import { FastifyInstance } from 'fastify';
 import UserController from '../../../controllers/userController';
+import { PostType } from './postQueries';
+import PostController from '../../../controllers/postController';
+import { ProfileType } from './profileQueries';
+import ProfileController from '../../../controllers/profileController';
+import { MemberTypeType } from './memberTypeQueries';
+import MemberTypeController from '../../../controllers/memberTypeController';
 
-const UserType = new GraphQLObjectType({
+export const UserType: GraphQLObjectType<any, any> = new GraphQLObjectType({
   name: 'User',
   fields: () => ({
     id: { type: GraphQLID },
@@ -15,6 +21,63 @@ const UserType = new GraphQLObjectType({
     lastName: { type: GraphQLString },
     email: { type: GraphQLString },
     subscribedToUserIds: { type: new GraphQLList(GraphQLID) },
+    posts: {
+      type: new GraphQLList(PostType),
+      resolve: async (
+        parent: any,
+        args: undefined,
+        context: FastifyInstance
+      ) => {
+        return new PostController(context).getUserPosts(parent.id);
+      },
+    },
+    profile: {
+      type: ProfileType,
+      resolve: async (
+        parent: any,
+        args: undefined,
+        context: FastifyInstance
+      ) => {
+        return new ProfileController(context).getUsersProfile(parent.id);
+      },
+    },
+    memberType: {
+      type: MemberTypeType,
+      resolve: async (
+        parent: any,
+        args: undefined,
+        context: FastifyInstance
+      ) => {
+        const profile = await new ProfileController(context).getUsersProfile(
+          parent.id
+        );
+        return await new MemberTypeController(context).getMemberTypeById(
+          profile.memberTypeId
+        );
+      },
+    },
+    subscribes: {
+      type: new GraphQLList(UserType),
+      resolve: async (
+        parent: any,
+        args: undefined,
+        context: FastifyInstance
+      ) => {
+        return await new UserController(context).getUserSubscribes(
+          parent.subscribedToUserIds
+        );
+      },
+    },
+    followers: {
+      type: new GraphQLList(UserType),
+      resolve: async (
+        parent: any,
+        args: undefined,
+        context: FastifyInstance
+      ) => {
+        return await new UserController(context).getUserFollowers(parent.id);
+      },
+    },
   }),
 });
 

--- a/src/routes/graphql/graphql-schema/schema.ts
+++ b/src/routes/graphql/graphql-schema/schema.ts
@@ -6,6 +6,19 @@ import {
   memberTypeQuery,
   memberTypesQuery,
 } from '../graphql-queries/memberTypeQueries';
+import {
+  addUserMutation,
+  updateUserMutation,
+} from '../graphql-mutations/userMutations';
+import {
+  addProfileMutation,
+  updateProfileMutation,
+} from '../graphql-mutations/profileMutations';
+import {
+  addPostMutation,
+  updatePostMutation,
+} from '../graphql-mutations/postMutations';
+import { updateMemberTypeMutation } from '../graphql-mutations/memberTypeMutations';
 
 const RootQuery = new GraphQLObjectType({
   name: 'RootQuery',
@@ -21,6 +34,20 @@ const RootQuery = new GraphQLObjectType({
   }),
 });
 
+const RootMutation = new GraphQLObjectType({
+  name: 'RootMutation',
+  fields: () => ({
+    addUser: addUserMutation,
+    updateUser: updateUserMutation,
+    addProfile: addProfileMutation,
+    updateProfile: updateProfileMutation,
+    addPost: addPostMutation,
+    updatePost: updatePostMutation,
+    updateMemberType: updateMemberTypeMutation,
+  }),
+});
+
 export default new GraphQLSchema({
   query: RootQuery,
+  mutation: RootMutation,
 });

--- a/src/routes/graphql/graphql-schema/schema.ts
+++ b/src/routes/graphql/graphql-schema/schema.ts
@@ -8,6 +8,8 @@ import {
 } from '../graphql-queries/memberTypeQueries';
 import {
   addUserMutation,
+  subscribeToUserMutation,
+  unsubscribeFromUserMutation,
   updateUserMutation,
 } from '../graphql-mutations/userMutations';
 import {
@@ -39,6 +41,8 @@ const RootMutation = new GraphQLObjectType({
   fields: () => ({
     addUser: addUserMutation,
     updateUser: updateUserMutation,
+    subscribeToUser: subscribeToUserMutation,
+    unsubscribeFromUser: unsubscribeFromUserMutation,
     addProfile: addProfileMutation,
     updateProfile: updateProfileMutation,
     addPost: addPostMutation,

--- a/src/routes/graphql/graphql-schema/schema.ts
+++ b/src/routes/graphql/graphql-schema/schema.ts
@@ -1,0 +1,26 @@
+import { GraphQLObjectType, GraphQLSchema } from 'graphql/type';
+import { userQuery, usersQuery } from '../graphql-queries/userQueries';
+import { postQuery, postsQuery } from '../graphql-queries/postQueries';
+import { profileQuery, profilesQuery } from '../graphql-queries/profileQueries';
+import {
+  memberTypeQuery,
+  memberTypesQuery,
+} from '../graphql-queries/memberTypeQueries';
+
+const RootQuery = new GraphQLObjectType({
+  name: 'RootQuery',
+  fields: () => ({
+    user: userQuery,
+    users: usersQuery,
+    profile: profileQuery,
+    profiles: profilesQuery,
+    post: postQuery,
+    posts: postsQuery,
+    memberType: memberTypeQuery,
+    memberTypes: memberTypesQuery,
+  }),
+});
+
+export default new GraphQLSchema({
+  query: RootQuery,
+});

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -16,6 +16,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
     async function (request, reply) {
       return await graphql({
         schema,
+        variableValues: request.body.variables,
         source: String(request.body.query),
         contextValue: fastify,
       });

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
-import { graphql } from 'graphql';
+import { graphql, validate, parse } from 'graphql';
+import * as depthLimit from 'graphql-depth-limit';
 import { graphqlBodySchema } from './schema';
 import schema from './graphql-schema/schema';
 
@@ -14,10 +15,18 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply) {
+      const source = request.body.query!;
+      const documentNode = parse(source);
+      const validationRules = [depthLimit(5)];
+
+      const depthErrors = validate(schema, documentNode, validationRules);
+
+      if (depthErrors.length) reply.send({ data: null, errors: depthErrors });
+
       return await graphql({
         schema,
+        source,
         variableValues: request.body.variables,
-        source: String(request.body.query),
         contextValue: fastify,
       });
     }

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,5 +1,7 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
+import { graphql } from 'graphql';
 import { graphqlBodySchema } from './schema';
+import schema from './graphql-schema/schema';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
@@ -11,7 +13,13 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: graphqlBodySchema,
       },
     },
-    async function (request, reply) {}
+    async function (request, reply) {
+      return await graphql({
+        schema,
+        source: String(request.body.query),
+        contextValue: fastify,
+      });
+    }
   );
 };
 

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -8,7 +8,9 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
 ): Promise<void> => {
   fastify.get('/', async function (request, reply): Promise<
     MemberTypeEntity[]
-  > {});
+  > {
+    return await fastify.db.memberTypes.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -17,7 +19,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      const memberType = await fastify.db.memberTypes.findOne({
+        key: 'id',
+        equals: request.params.id,
+      });
+      if (!memberType) {
+        throw reply.notFound('No member types with such id');
+      }
+      return memberType;
+    }
   );
 
   fastify.patch(
@@ -28,7 +39,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      if (!Object.keys(request.body).length) {
+        throw reply.badRequest('Add fields you want to update');
+      }
+      const updatedMemberType = await fastify.db.memberTypes.change(
+        request.params.id,
+        request.body
+      );
+      return updatedMemberType;
+    }
   );
 };
 

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -2,14 +2,17 @@ import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-sc
 import { idParamSchema } from '../../utils/reusedSchemas';
 import { changeMemberTypeBodySchema } from './schema';
 import type { MemberTypeEntity } from '../../utils/DB/entities/DBMemberTypes';
+import MemberTypeController from '../../controllers/memberTypeController';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
+  const controller = new MemberTypeController(fastify);
+
   fastify.get('/', async function (request, reply): Promise<
     MemberTypeEntity[]
   > {
-    return await fastify.db.memberTypes.findMany();
+    return await controller.getAllMemberTypes();
   });
 
   fastify.get(
@@ -20,14 +23,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply): Promise<MemberTypeEntity> {
-      const memberType = await fastify.db.memberTypes.findOne({
-        key: 'id',
-        equals: request.params.id,
-      });
-      if (!memberType) {
-        throw reply.notFound('No member types with such id');
-      }
-      return memberType;
+      return await controller.getMemberTypeById(request.params.id);
     }
   );
 
@@ -40,14 +36,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
       },
     },
     async function (request, reply): Promise<MemberTypeEntity> {
-      if (!Object.keys(request.body).length) {
-        throw reply.badRequest('Add fields you want to update');
-      }
-      const updatedMemberType = await fastify.db.memberTypes.change(
-        request.params.id,
-        request.body
-      );
-      return updatedMemberType;
+      return await controller.updateMemberType(request.params.id, request.body);
     }
   );
 };

--- a/src/routes/posts/index.ts
+++ b/src/routes/posts/index.ts
@@ -2,11 +2,14 @@ import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-sc
 import { idParamSchema } from '../../utils/reusedSchemas';
 import { createPostBodySchema, changePostBodySchema } from './schema';
 import type { PostEntity } from '../../utils/DB/entities/DBPosts';
+import { NoRequiredEntity } from '../../utils/DB/errors/NoRequireEntity.error';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<PostEntity[]> {
+    return await fastify.db.posts.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -15,7 +18,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      const post = await fastify.db.posts.findOne({
+        key: 'id',
+        equals: request.params.id,
+      });
+      if (!post) {
+        throw reply.notFound('No posts with such id');
+      }
+      return post;
+    }
   );
 
   fastify.post(
@@ -25,7 +37,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createPostBodySchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      const newPost = await fastify.db.posts.create(request.body);
+      return newPost;
+    }
   );
 
   fastify.delete(
@@ -35,7 +50,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      try {
+        const post = await fastify.db.posts.delete(request.params.id);
+        return post;
+      } catch (err) {
+        throw err instanceof NoRequiredEntity
+          ? reply.badRequest('No posts with such id')
+          : err;
+      }
+    }
   );
 
   fastify.patch(
@@ -46,7 +70,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<PostEntity> {}
+    async function (request, reply): Promise<PostEntity> {
+      if (!Object.keys(request.body).length) {
+        throw reply.badRequest('Add fields you want to update');
+      }
+      const updatedPost = await fastify.db.posts.change(
+        request.params.id,
+        request.body
+      );
+      return updatedPost;
+    }
   );
 };
 

--- a/src/routes/profiles/index.ts
+++ b/src/routes/profiles/index.ts
@@ -2,13 +2,14 @@ import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-sc
 import { idParamSchema } from '../../utils/reusedSchemas';
 import { createProfileBodySchema, changeProfileBodySchema } from './schema';
 import type { ProfileEntity } from '../../utils/DB/entities/DBProfiles';
+import { NoRequiredEntity } from '../../utils/DB/errors/NoRequireEntity.error';
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<
-    ProfileEntity[]
-  > {});
+  fastify.get('/', async function (request, reply): Promise<ProfileEntity[]> {
+    return await fastify.db.profiles.findMany();
+  });
 
   fastify.get(
     '/:id',
@@ -17,7 +18,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const profile = await fastify.db.profiles.findOne({
+        key: 'id',
+        equals: request.params.id,
+      });
+      if (!profile) {
+        throw reply.notFound('No profiles with such id');
+      }
+      return profile;
+    }
   );
 
   fastify.post(
@@ -27,7 +37,24 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createProfileBodySchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      const allowedMemberType = await fastify.db.memberTypes.findOne({
+        key: 'id',
+        equals: request.body.memberTypeId,
+      });
+      const userAlreadyHasProfile = await fastify.db.profiles.findOne({
+        key: 'userId',
+        equals: request.body.userId,
+      });
+      if (userAlreadyHasProfile) {
+        throw reply.badRequest('User with this id already have a profile');
+      }
+      if (!allowedMemberType) {
+        throw reply.badRequest("No such member id's");
+      }
+      const profile = fastify.db.profiles.create(request.body);
+      return profile;
+    }
   );
 
   fastify.delete(
@@ -37,7 +64,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      try {
+        const profile = await fastify.db.profiles.delete(request.params.id);
+        return profile;
+      } catch (err) {
+        throw err instanceof NoRequiredEntity
+          ? reply.badRequest('No profiles with such id')
+          : err;
+      }
+    }
   );
 
   fastify.patch(
@@ -48,7 +84,16 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<ProfileEntity> {}
+    async function (request, reply): Promise<ProfileEntity> {
+      if (!Object.keys(request.body).length) {
+        throw reply.badRequest('Add fields you want to update');
+      }
+      const updatedProfile = await fastify.db.profiles.change(
+        request.params.id,
+        request.body
+      );
+      return updatedProfile;
+    }
   );
 };
 

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -69,6 +69,22 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
             subscribedToUserIds: updatedSubscribes,
           });
         }
+        const userPosts = await fastify.db.posts.findMany({
+          key: 'userId',
+          equals: user.id,
+        });
+        if (userPosts.length) {
+          for (const userPost of userPosts) {
+            await fastify.db.posts.delete(userPost.id);
+          }
+        }
+        const userProfile = await fastify.db.profiles.findOne({
+          key: 'userId',
+          equals: user.id,
+        });
+        if (userProfile) {
+          await fastify.db.profiles.delete(userProfile.id);
+        }
         return user;
       } catch (err) {
         throw err instanceof NoRequiredEntity


### PR DESCRIPTION
1. Task: https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/assignment.md
2. Done: 31.01.2023 / Deadline: 31.01.2023
3. Score: 260/360
4. Selfcheck:
### Basic Scope
- [x] Task 1: restful endpoints. (**+72**)
- [x] Subtasks 2.1-2.7: get gql queries. (**+72**)
- [x] Subtasks 2.8-2.11: create gql queries. (**+48 / 54**)
- [x] Subtasks 2.12-2.17: update gql queries. (**+48 / 54**)
- [ ] Task 3: solve n+1 graphql problem. (**+88**)
- [x] Task 4: limit the complexity of the graphql queries. (**+20**)
### Forfeits
- [ ] -30% of max task score Commits after deadline (except commits that affect only Readme.md, .gitignore, etc.)
- [ ] -60% of max task score Samples of POST body for gql requests were not provided for those subtasks that were declared to be completed.
- [ ] -100% of max task score Tests have been modified.
- [ ] -20 No separate development branch
- [ ] -20 No Pull Request
- [ ] -10 Pull Request description is incorrect
- [ ] -20 Less than 3 commits in the development branch, not including commits that make changes only to Readme.md or similar files (tsconfig.json, .gitignore, .prettierrc.json, etc.)

5. Examples of graphQL queries
- 2.1 Get users, profiles, posts, memberTypes - 4 operations in one query.
```
query {
  users {id}
  posts {id}
  profiles {id}
  memberTypes {id}
}
```
- 2.2 Get user, profile, post, memberType by id - 4 operations in one query.
```
query (
  $userId: ID!,
  $postId: ID!,
  $profileId: ID!,
  $memberTypeId: String!
) {
  user(id: $userId) {
    firstName
  }
  post(id: $postId) {
    content
  }
  profile(id: $profileId) {
    country
  }
  memberType(id: $memberTypeId) {
    discount
  }
}
```
- 2.3 Get users with their posts, profiles, memberTypes.
```
query {
  users {
    id
    posts {id}
    profile {id}
    memberType {id}
  }
}
```
- 2.4 Get user by id with his posts, profile, memberType.
```
query ($id: ID!) {
  user(id: $id) {
    firstName
    posts {id}
    profile {id}
    memberType {id}
  }
}
```
- 2.5 Get users with their `userSubscribedTo`, profile.
```
query {
  users {
    subscribes {
      profile {
        country
        city
      }
    }
  }
}
```
- 2.6 Get user by id with his `subscribedToUser`, posts.
```
query ($id: ID!) {
  user (id: $id) {
    followers {
      posts {
        id
      }
    }
  }
}
```
- 2.7 Get users with their `userSubscribedTo`, `subscribedToUser` (additionally for each user in `userSubscribedTo`, `subscribedToUser` add their `userSubscribedTo`, `subscribedToUser`).
```
query {
  users {
    subscribes {
      subscribes {id}
      followers {id}
    }
    followers {
      subscribes {id}
      followers {id}
    }
  }
}
```
- 2.8 Create user.
```
mutation (
  $firstName: String!
  $lastName: String!
  $email: String!
) {
  addUser(
    firstName: $firstName,
    lastName: $lastName,
    email: $email
  ) {
      firstName
      lastName
      email
      id
    }
}
```
- 2.9 Create profile.
```
mutation (
  $avatar: String!,
  $sex: String!,
  $birthday: Int!,
  $country: String!,
  $street: String!,
  $city: String!,
  $memberTypeId: String!,
  $userId: String!
) {
  addProfile (
    avatar: $avatar,
    sex: $sex,
    birthday: $birthday,
    country: $country,
    street: $street,
    city: $city,
    memberTypeId: $memberTypeId,
    userId: $userId
  ) {
    avatar
    sex
    birthday
    country
    street
    city
    memberTypeId
    userId
    id
  }
}
```
- 2.10 Create post.
```
mutation (
  $title: String!,
  $content: String!,
  $userId: String!
) {
  addPost (
    title: $title,
    content: $content,
    userId: $userId,
  ) {
    title
    content
    userId
    id
  }
}

```
- 2.11 [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.
```
some code
```
- 2.12 Update user.
```
mutation (
    $id: ID!,
    $firstName: String,
    $lastName: String,
    $email: String,
    $subscribedToUserIds: [String],
) {
    updateUser (
      id: $id,
      firstName: $firstName,
      lastName: $lastName,
      email: $email,
      subscribedToUserIds : $subscribedToUserIds
    ) {
    	id
        firstName
    	lastName
    	email
    	subscribedToUserIds
      }
   }
```
- 2.13 Update profile.
```
mutation (
    $id: ID!,
    $avatar: String,
    $sex: String,
    $birthday: Int,
    $country: String,
    $street: String,
    $city: String,
    $memberTypeId: String
) {
  updateProfile (
    id: $id,
    avatar: $avatar, 
    sex: $sex, 
    birthday: $birthday,
    country: $country, 
    street: $street, 
    city: $city, 
    memberTypeId: $memberTypeId
  ) {
      id
      avatar
      sex
      birthday
      country
      street
      city
      memberTypeId
      userId
  }
}
```
- 2.14 Update post.
```
mutation (
  $id: ID!,
  $title: String,
  $content: String
) {
  updatePost (id: $id, title: $title, content: $content) {
    id
    title
    content
    userId
  }
}
```
- 2.15 Update memberType.
```
mutation($id: String!, $discount: Int, $monthPostsLimit: Int) {
  updateMemberType(
    id: $id
    discount: $discount
    monthPostsLimit: $monthPostsLimit
  ) {
    id
    discount
    monthPostsLimit
  }
}
```
- 2.16 Subscribe to; unsubscribe from.
```
mutation($userId: ID!, $subscribedTo: ID!) {
  subscribeToUser(userId: $userId, subscribedTo: $subscribedTo) {
    subscribedToUserIds
  }
}
```
- 2.17 [InputObjectType](https://graphql.org/graphql-js/type/#graphqlinputobjecttype) for DTOs.
```
some code
```

- 4 Limit the complexity of the graphql queries by their depth with [graphql-depth-limit](https://www.npmjs.com/package/graphql-depth-limit) package.
  - 4.1 Provide a link to the line of code where it was used.
    > `src/routes/graphql/index.ts` **Line 22**
  - 4.2 Specify a `POST` body of gql query that ends with an error due to the operation of the rule. Request result should be with errors field (and with or without `data:null`) describing the error.
```
query {
  users {
    followers {
      subscribes {
        followers {
          subscribes {
            followers {
              subscribes {
                firstName
              }
            }
          }
        }
      }
    }
  }
}

```